### PR TITLE
Use `oboInOwl:evidence` for assay annotation mapping in taxonomy class pattern

### DIFF
--- a/src/patterns/dosdp-patterns/taxonomy_class.yaml
+++ b/src/patterns/dosdp-patterns/taxonomy_class.yaml
@@ -34,7 +34,7 @@ annotationProperties:
   'has nsforest marker': "PCL:0010058"
   some_soma_located_in: "CLM:0010001"
 #  assay_label: "PCL:0010064"
-  assay: "OBI:0000070"
+  assay: "oboInOwl:evidence"
   cell_ratio: "CLM:0010002"
   'has minimal marker': "PCL:0010066"
   evidence: "oboInOwl:evidence"


### PR DESCRIPTION
This PR updates the DOSDP taxonomy class pattern to use `oboInOwl:evidence` for the `assay` annotation property mapping.
