### PR TITLE
Fix dendrogram build dependencies and stabilize local release tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ src/patterns/all_pattern_terms.txt
 # Local/generated artifacts
 src/scripts/__pycache__/
 src/ontology/imports/genedb_import.owl
+node_modules/
+typescript/dist/
+src/dendrograms/package.json
+src/dendrograms/package-lock.json

--- a/src/dendrograms/Makefile
+++ b/src/dendrograms/Makefile
@@ -13,6 +13,8 @@ ABC_URLS_MARKER_SET = $(patsubst %, ./%_abc_urls_marker_set.json, $(JOBS))
 ABC_URLS_EVIDENCE_MARKER_SET = $(patsubst %, ./%_abc_urls_evidence_marker_set.json, $(JOBS))
 ABC_URLS_NSFOREST_MARKER_SET = $(patsubst %, ./%_abc_urls_nsforest_marker_set.json, $(JOBS))
 ABC_URLS_WS_MARKER_SET = $(patsubst %, ./%_abc_urls_ws_marker_set.json, $(JOBS))
+TYPESCRIPT_SOURCES = $(wildcard ../../typescript/src/*.ts ../../typescript/src/abc-atlas/*.ts)
+TYPESCRIPT_DIST_FILES = ../../typescript/dist/index.js ../../typescript/dist/index_genes.js
 
 SHEETS_SCRIPT := ../scripts/google_sheets_to_tsv.py
 TAXONOMY_URL := https://raw.githubusercontent.com/brain-bican/basal_ganglia_consensus_taxonomy/refs/heads/main/CS20250428.json
@@ -33,14 +35,14 @@ CCN20250428.json: FORCE
 
 FORCE:
 
-../templates/%.tsv: %.json ../patterns/data/default/%_class_curation.tsv
+../templates/%.tsv: %.json ../patterns/data/default/%_class_curation.tsv %_abc_urls.json
 	python ../scripts/template_runner.py generator -i $< -o $@
 
 #../markers/%_markers_denormalized.tsv: %.json nomenclature_table_%.csv
 #	if [ $< = CS1908210.json ]; then python ../scripts/template_runner.py generator -md -i $< -o $@ ;\
 #	else python ../scripts/template_runner.py generator -md -i $(word 2, $^) -o $@ ; fi
 
-../patterns/data/default/%_class_base.tsv: %.json $(SUPPLEMENTARY)/neurotransmitters.tsv
+../patterns/data/default/%_class_base.tsv: %.json $(SUPPLEMENTARY)/neurotransmitters.tsv %_abc_urls.json
 	python ../scripts/template_runner.py generator -cb -i $< -o $@
 
 ../patterns/data/default/%_class_curation.tsv: %.json
@@ -61,13 +63,9 @@ $(SUPPLEMENTARY)/neurotransmitters.tsv:
 ../patterns/data/default/%_evidence_marker_set.tsv: %.json
 	python ../scripts/template_runner.py generator -ems -i $< -o $@
 
-prepare_npm: ../../typescript/dist/index.js
-	rm -rf ../../typescript/dist
-	npm install typescript
-
-../../typescript/dist/index.js: prepare_npm ../../typescript/tsconfig.json  ../../typescript/src/index.ts
-	npm install --prefix ../../typescript typescript @types/node --save-dev
-	npx tsc -p ../../typescript/tsconfig.json
+$(TYPESCRIPT_DIST_FILES): ../../typescript/package.json ../../typescript/package-lock.json ../../typescript/tsconfig.json $(TYPESCRIPT_SOURCES)
+	npm install --prefix ../../typescript
+	npx --prefix ../../typescript tsc -p ../../typescript/tsconfig.json
 
 CCN20250428_abc_urls.json: ../../typescript/dist/index.js
 	node $< $@
@@ -83,5 +81,3 @@ CCN20250428_abc_urls_nsforest_marker_set.json: ../../typescript/dist/index_genes
 
 CCN20250428_abc_urls_ws_marker_set.json: ../../typescript/dist/index_genes.js ../patterns/data/default/CCN20250428_within_subclass_marker_set.tsv
 	node $< $(word 2, $^) $@
-
-

--- a/src/scripts/supplementary_data_processor.py
+++ b/src/scripts/supplementary_data_processor.py
@@ -13,6 +13,13 @@ def generate_neurotransmitter_data(output_file: str):
         output_file: Output file path.
     """
     print("Generate neurotransmitter data")
+    if not os.path.exists(C2C_ANNOTATION_MEMBERSHIP):
+        if output_file and os.path.exists(output_file):
+            print(f"Supplementary source missing at {C2C_ANNOTATION_MEMBERSHIP}; reusing existing {output_file}")
+            return
+        raise FileNotFoundError(
+            f"Missing supplementary source: {C2C_ANNOTATION_MEMBERSHIP}"
+        )
     df = pd.read_csv(C2C_ANNOTATION_MEMBERSHIP)
 
     cluster_records = df[df['cluster_annotation_term_set_name'] == 'cluster']

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "types": ["node"],
     "jsx": "react-jsx",
     "skipLibCheck": true


### PR DESCRIPTION
This PR fixes the release build path that caused Allen Brain Atlas links to disappear from regenerated ontology artifacts, and cleans up local tooling issues that made the problem harder to reproduce and fix reliably.

What changed

- Fix the dendrogram Makefile dependency graph so %_abc_urls.json is a declared prerequisite for:
  - ../patterns/data/default/%_class_base.tsv
  - ../templates/%.tsv
- Update the TypeScript build step in src/dendrograms/Makefile to run npm and tsc only under typescript/
  - removes the bad npm side effects in src/dendrograms/
  - removes the previous circular build setup around prepare_npm
- Ignore generated Node artifacts in .gitignore
  - node_modules/
  - typescript/dist/
  - accidental src/dendrograms/package.json
  - accidental src/dendrograms/package-lock.json
- Fix the TypeScript config mismatch in typescript/tsconfig.json
  - ignoreDeprecations changed from 6.0 to 5.0 to match the installed TS toolchain
- Make supplementary_data_processor.py tolerate the missing local-only supplementary CSV by reusing the existing generated supplementary/neurotransmitters.tsv instead of failing immediately